### PR TITLE
Add browser auto-detection and custom browser path support

### DIFF
--- a/.github/workflows/browser-integration-test.yml
+++ b/.github/workflows/browser-integration-test.yml
@@ -76,6 +76,7 @@ jobs:
           Write-Output $output
           if ($output -match "Attempting login") {
             Write-Output "SUCCESS: Browser opened and reached skool.com"
+            exit 0
           } else {
             Write-Error "FAIL: Did not reach login attempt — browser may not have opened"
             exit 1

--- a/.github/workflows/browser-integration-test.yml
+++ b/.github/workflows/browser-integration-test.yml
@@ -1,0 +1,82 @@
+name: Browser Integration Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  browser-test:
+    name: Browser Launch Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+
+      - name: Build (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: go build -v -o skool-downloader .
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: go build -v -o skool-downloader.exe .
+
+      # Run with fake credentials against the real skool.com URL.
+      # The program opens the browser, navigates to skool.com, and prints
+      # "Attempting login" before filling the form. Seeing that line proves
+      # the browser launched and reached the site. The process will exit
+      # non-zero (invalid credentials) — that is expected and allowed.
+      - name: Test browser launch and login attempt (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          output=$(./skool-downloader \
+            -url="https://www.skool.com/test/classroom/abc" \
+            -email="test@example.com" \
+            -password="testpassword123" \
+            -browser="${{ steps.setup-chrome.outputs.chrome-path }}" \
+            -wait=1 \
+            2>&1) || true
+          echo "$output"
+          if echo "$output" | grep -q "Attempting login"; then
+            echo "SUCCESS: Browser opened and reached skool.com"
+          else
+            echo "FAIL: Did not reach login attempt — browser may not have opened"
+            exit 1
+          fi
+
+      - name: Test browser launch and login attempt (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $output = & .\skool-downloader.exe `
+            "-url=https://www.skool.com/test/classroom/abc" `
+            "-email=test@example.com" `
+            "-password=testpassword123" `
+            "-browser=${{ steps.setup-chrome.outputs.chrome-path }}" `
+            "-wait=1" 2>&1 | Out-String
+          Write-Output $output
+          if ($output -match "Attempting login") {
+            Write-Output "SUCCESS: Browser opened and reached skool.com"
+          } else {
+            Write-Error "FAIL: Did not reach login attempt — browser may not have opened"
+            exit 1
+          }

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Progra
 ```
 
 > [!NOTE]
-> Safari is not supported. Firefox support relies on its experimental CDP implementation (available since Firefox 86) and works best with email/password login; cookie-based auth may have limited compatibility.
+> Safari is not supported. Firefox support requires Firefox **86–129**; Firefox 130+ switched to WebDriver BiDi which is not compatible with this tool. Cookie-based auth with Firefox may have limited compatibility.
 
 ### Authentication Methods
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Use this tool only to download content you have the right to access. Please resp
 - Automatically detects and normalizes video URLs
 - Configurable page loading wait time
 - Toggleable headless mode for debugging
+- Auto-detects any installed Chromium-based browser — no Google Chrome required
 
 ## Installation
 
@@ -84,7 +85,34 @@ go build
 -output     Directory to save videos (default: "downloads")
 -wait       Page load wait time in seconds (default: 2)
 -headless   Run browser headless (default: true, set false for debugging)
+-browser    Path or command of the browser to use (auto-detected if not set)
 ```
+
+### Browser Support
+
+The tool works with any installed Chromium-based browser and does **not** require Google Chrome. On startup it searches for a supported browser automatically, in this order:
+
+| Platform | Detection order |
+|----------|----------------|
+| **Windows** | Microsoft Edge (built-in on Win 10/11) → Chrome → Chromium → Brave |
+| **macOS** | Chrome → Chromium → Edge → Brave → Arc |
+| **Linux** | `chromium-browser` → `chromium` → `google-chrome` → `microsoft-edge` → `brave-browser` |
+
+The first browser found is used. If you want to use a specific browser, or if auto-detection fails, pass its path explicitly with `-browser`:
+
+```bash
+# Use a specific browser by absolute path
+./skool-downloader -url="..." -email="..." -password="..." -browser="/usr/bin/chromium"
+
+# Use a browser command available in PATH (Linux/macOS)
+./skool-downloader -url="..." -email="..." -password="..." -browser="brave-browser"
+
+# Windows example
+skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
+```
+
+> [!NOTE]
+> Only Chromium-based browsers are supported (Chrome, Edge, Chromium, Brave, Arc, Opera, …). Firefox and Safari cannot be used because they do not implement the Chrome DevTools Protocol that the tool relies on.
 
 ### Authentication Methods
 
@@ -117,6 +145,8 @@ If you choose to use cookies instead of email/password:
 - **Download errors**: Update yt-dlp (`pip install -U yt-dlp`)
 - **Login issues**: Try `-headless=false` to see the browser and debug
 - **Specific video errors**: Check if the video is still available on Loom
+- **No browser found**: Install Microsoft Edge, Chrome, Chromium, or Brave — or point to an existing one with `-browser=/path/to/browser`
+- **Wrong browser launched**: Override auto-detection with `-browser=` to pick the exact executable you want
 
 ## Development and Testing
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ go build
 
 ### Browser Support
 
-The tool does **not** require Google Chrome. On startup it searches for a supported Chromium-based browser automatically:
+The tool requires a Chromium-based browser. On startup it searches for a supported Chromium-based browser automatically: Unfortunatelly Safari and Firefox cannot be supported as of now.
 
 | Platform | Detection order |
 |----------|----------------|

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use this tool only to download content you have the right to access. Please resp
 - Automatically detects and normalizes video URLs
 - Configurable page loading wait time
 - Toggleable headless mode for debugging
-- Auto-detects any installed Chromium-based browser — no Google Chrome required
+- Auto-detects any installed browser — supports Chromium-based browsers and Firefox
 
 ## Installation
 
@@ -90,29 +90,29 @@ go build
 
 ### Browser Support
 
-The tool works with any installed Chromium-based browser and does **not** require Google Chrome. On startup it searches for a supported browser automatically, in this order:
+The tool does **not** require Google Chrome. On startup it searches for a supported browser automatically, preferring Chromium-based browsers (better CDP support) with Firefox as a fallback:
 
 | Platform | Detection order |
 |----------|----------------|
-| **Windows** | Microsoft Edge (built-in on Win 10/11) → Chrome → Chromium → Brave |
-| **macOS** | Chrome → Chromium → Edge → Brave → Arc |
-| **Linux** | `chromium-browser` → `chromium` → `google-chrome` → `microsoft-edge` → `brave-browser` |
+| **Windows** | Edge (built-in) → Chrome → Chromium → Brave → Firefox |
+| **macOS** | Chrome → Chromium → Edge → Brave → Arc → Firefox |
+| **Linux** | `chromium-browser` → `chromium` → `google-chrome` → `microsoft-edge` → `brave-browser` → `firefox` → `firefox-esr` |
 
-The first browser found is used. If you want to use a specific browser, or if auto-detection fails, pass its path explicitly with `-browser`:
+The first browser found is used. To pick a specific browser, or if auto-detection fails, use `-browser`:
 
 ```bash
-# Use a specific browser by absolute path
-./skool-downloader -url="..." -email="..." -password="..." -browser="/usr/bin/chromium"
+# Absolute path
+./skool-downloader -url="..." -email="..." -password="..." -browser="/usr/bin/firefox"
 
-# Use a browser command available in PATH (Linux/macOS)
+# Command available in PATH (Linux/macOS)
 ./skool-downloader -url="..." -email="..." -password="..." -browser="brave-browser"
 
 # Windows example
-skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
+skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Program Files\Mozilla Firefox\firefox.exe"
 ```
 
 > [!NOTE]
-> Only Chromium-based browsers are supported (Chrome, Edge, Chromium, Brave, Arc, Opera, …). Firefox and Safari cannot be used because they do not implement the Chrome DevTools Protocol that the tool relies on.
+> Safari is not supported. Firefox support relies on its experimental CDP implementation (available since Firefox 86) and works best with email/password login; cookie-based auth may have limited compatibility.
 
 ### Authentication Methods
 
@@ -145,7 +145,7 @@ If you choose to use cookies instead of email/password:
 - **Download errors**: Update yt-dlp (`pip install -U yt-dlp`)
 - **Login issues**: Try `-headless=false` to see the browser and debug
 - **Specific video errors**: Check if the video is still available on Loom
-- **No browser found**: Install Microsoft Edge, Chrome, Chromium, or Brave — or point to an existing one with `-browser=/path/to/browser`
+- **No browser found**: Install Edge, Chrome, Chromium, Brave, or Firefox — or point to an existing one with `-browser=/path/to/browser`
 - **Wrong browser launched**: Override auto-detection with `-browser=` to pick the exact executable you want
 
 ## Development and Testing

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use this tool only to download content you have the right to access. Please resp
 - Automatically detects and normalizes video URLs
 - Configurable page loading wait time
 - Toggleable headless mode for debugging
-- Auto-detects any installed browser — supports Chromium-based browsers and Firefox
+- Auto-detects any installed Chromium-based browser
 
 ## Installation
 
@@ -85,34 +85,34 @@ go build
 -output     Directory to save videos (default: "downloads")
 -wait       Page load wait time in seconds (default: 2)
 -headless   Run browser headless (default: true, set false for debugging)
--browser    Path or command of the browser to use (auto-detected if not set)
+-browser    Path or command of a Chromium-based browser (auto-detected if not set)
 ```
 
 ### Browser Support
 
-The tool does **not** require Google Chrome. On startup it searches for a supported browser automatically, preferring Chromium-based browsers (better CDP support) with Firefox as a fallback:
+The tool does **not** require Google Chrome. On startup it searches for a supported Chromium-based browser automatically:
 
 | Platform | Detection order |
 |----------|----------------|
-| **Windows** | Edge (built-in) → Chrome → Chromium → Brave → Firefox |
-| **macOS** | Chrome → Chromium → Edge → Brave → Arc → Firefox |
-| **Linux** | `chromium-browser` → `chromium` → `google-chrome` → `microsoft-edge` → `brave-browser` → `firefox` → `firefox-esr` |
+| **Windows** | `msedge`, `chrome`, `chromium` (PATH) → Edge default install |
+| **macOS** | Chrome → Chromium → Edge → Brave (`/Applications/`) |
+| **Linux** | `chromium-browser` → `chromium` → `google-chrome` → `microsoft-edge` → `brave-browser` (PATH) |
 
 The first browser found is used. To pick a specific browser, or if auto-detection fails, use `-browser`:
 
 ```bash
 # Absolute path
-./skool-downloader -url="..." -email="..." -password="..." -browser="/usr/bin/firefox"
+./skool-downloader -url="..." -email="..." -password="..." -browser="/usr/bin/chromium"
 
 # Command available in PATH (Linux/macOS)
 ./skool-downloader -url="..." -email="..." -password="..." -browser="brave-browser"
 
 # Windows example
-skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Program Files\Mozilla Firefox\firefox.exe"
+skool-downloader.exe -url="..." -email="..." -password="..." -browser="C:\Program Files\Google\Chrome\Application\chrome.exe"
 ```
 
 > [!NOTE]
-> Safari is not supported. Firefox support requires Firefox **86–129**; Firefox 130+ switched to WebDriver BiDi which is not compatible with this tool. Cookie-based auth with Firefox may have limited compatibility.
+> Only Chromium-based browsers are supported (Chrome, Chromium, Edge, Brave). Safari and Firefox are not supported.
 
 ### Authentication Methods
 
@@ -145,7 +145,7 @@ If you choose to use cookies instead of email/password:
 - **Download errors**: Update yt-dlp (`pip install -U yt-dlp`)
 - **Login issues**: Try `-headless=false` to see the browser and debug
 - **Specific video errors**: Check if the video is still available on Loom
-- **No browser found**: Install Edge, Chrome, Chromium, Brave, or Firefox — or point to an existing one with `-browser=/path/to/browser`
+- **No browser found**: Install Edge, Chrome, Chromium, or Brave — or point to an existing one with `-browser=/path/to/browser`
 - **Wrong browser launched**: Override auto-detection with `-browser=` to pick the exact executable you want
 
 ## Development and Testing

--- a/skool-downloader.go
+++ b/skool-downloader.go
@@ -143,7 +143,21 @@ func parseFlags() Config {
 
 func validateConfig(config Config) {
 	if config.SkoolURL == "" {
-		fmt.Println("Usage: skool-downloader -url=https://skool.com/yourschool/classroom/path [-cookies=cookies.json | -email=user@example.com -password=pass]")
+		fmt.Println("Usage: skool-downloader -url=https://skool.com/yourschool/classroom/path [-cookies=cookies.json | -email=user@example.com -password=pass] [-browser=/path/to/browser]")
+		fmt.Println()
+		fmt.Println("Flags:")
+		fmt.Println("  -url        Skool classroom URL to scrape (required)")
+		fmt.Println("  -email      Email address for Skool login")
+		fmt.Println("  -password   Password for Skool login (required with -email)")
+		fmt.Println("  -cookies    Path to cookies file (JSON or Netscape .txt)")
+		fmt.Println("  -output     Directory to save downloaded videos (default: \"downloads\")")
+		fmt.Println("  -wait       Seconds to wait for page load (default: 2)")
+		fmt.Println("  -headless   Run browser in headless mode (default: true)")
+		fmt.Println("  -browser    Path or command of Chromium-based browser to use")
+		fmt.Println("              Auto-detected in this order:")
+		fmt.Println("                Windows : Edge > Chrome > Chromium > Brave")
+		fmt.Println("                macOS   : Chrome > Chromium > Edge > Brave > Arc")
+		fmt.Println("                Linux   : chromium-browser, chromium, google-chrome, ...")
 		os.Exit(1)
 	}
 

--- a/skool-downloader.go
+++ b/skool-downloader.go
@@ -254,6 +254,10 @@ func setupBrowser(headless bool, browserPath string) (context.Context, context.C
 		return nil, nil, err
 	}
 
+	if strings.Contains(strings.ToLower(filepath.Base(resolvedPath)), "firefox") {
+		return nil, nil, fmt.Errorf("Firefox is not supported. Please use a Chromium-based browser (Chrome, Chromium, Edge, Brave)")
+	}
+
 	fmt.Printf("%s Using browser: %s\n", prefixInfo, resolvedPath)
 
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],

--- a/skool-downloader_test.go
+++ b/skool-downloader_test.go
@@ -141,7 +141,6 @@ func TestParseInt64(t *testing.T) {
 }
 
 func TestConvertJSONToNetscapeCookies(t *testing.T) {
-	// Create a temporary JSON cookies file
 	tmpDir := t.TempDir()
 	jsonFile := filepath.Join(tmpDir, "cookies.json")
 
@@ -183,7 +182,6 @@ func TestConvertJSONToNetscapeCookies(t *testing.T) {
 		}
 	}()
 
-	// Read the converted file
 	content, err := os.ReadFile(netscapeFile)
 	if err != nil {
 		t.Fatalf("Failed to read converted file: %v", err)
@@ -191,12 +189,10 @@ func TestConvertJSONToNetscapeCookies(t *testing.T) {
 
 	contentStr := string(content)
 
-	// Check for header
 	if !contains(contentStr, "# Netscape HTTP Cookie File") {
 		t.Error("Missing Netscape header")
 	}
 
-	// Check for cookie data
 	if !contains(contentStr, "test_cookie") {
 		t.Error("Missing test_cookie in output")
 	}
@@ -268,7 +264,6 @@ func TestParseJSONCookies(t *testing.T) {
 		t.Errorf("Expected 2 cookies, got %d", len(cookies))
 	}
 
-	// Check first cookie
 	if cookies[0].Name != "cookie1" {
 		t.Errorf("Expected name 'cookie1', got '%s'", cookies[0].Name)
 	}
@@ -288,7 +283,6 @@ func TestParseJSONCookies(t *testing.T) {
 		t.Errorf("Expected SameSite Lax, got %v", cookies[0].SameSite)
 	}
 
-	// Check second cookie
 	if cookies[1].Name != "cookie2" {
 		t.Errorf("Expected name 'cookie2', got '%s'", cookies[1].Name)
 	}
@@ -328,7 +322,6 @@ www.example.com	TRUE	/test	FALSE	0	cookie2	value2
 		t.Errorf("Expected 3 cookies, got %d", len(cookies))
 	}
 
-	// Check first cookie
 	if cookies[0].Name != "cookie1" {
 		t.Errorf("Expected name 'cookie1', got '%s'", cookies[0].Name)
 	}
@@ -342,7 +335,6 @@ www.example.com	TRUE	/test	FALSE	0	cookie2	value2
 		t.Error("Expected Secure to be true")
 	}
 
-	// Check second cookie
 	if cookies[1].Name != "cookie2" {
 		t.Errorf("Expected name 'cookie2', got '%s'", cookies[1].Name)
 	}
@@ -353,7 +345,6 @@ www.example.com	TRUE	/test	FALSE	0	cookie2	value2
 		t.Error("Expected Secure to be false")
 	}
 
-	// Check third cookie
 	if cookies[2].Name != "cookie3" {
 		t.Errorf("Expected name 'cookie3', got '%s'", cookies[2].Name)
 	}
@@ -491,7 +482,6 @@ func TestFindBrowser_InvalidCustomPath(t *testing.T) {
 }
 
 func TestFindBrowser_InvalidBareCommand(t *testing.T) {
-	// A command name that is very unlikely to exist in PATH
 	_, err := findBrowser("skool-nonexistent-browser-xyz")
 	if err == nil {
 		t.Error("Expected error for unknown browser command, got nil")
@@ -505,7 +495,6 @@ func TestGetBrowserCandidates_NotEmpty(t *testing.T) {
 	}
 }
 
-// Helper function
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInner(s, substr)))
 }

--- a/skool-downloader_test.go
+++ b/skool-downloader_test.go
@@ -505,41 +505,6 @@ func TestGetBrowserCandidates_NotEmpty(t *testing.T) {
 	}
 }
 
-func TestIsFirefox(t *testing.T) {
-	tests := []struct {
-		path     string
-		expected bool
-	}{
-		{"/usr/bin/firefox", true},
-		{"/usr/bin/firefox-esr", true},
-		{`C:\Program Files\Mozilla Firefox\firefox.exe`, true},
-		{"/Applications/Firefox.app/Contents/MacOS/firefox", true},
-		{"/usr/bin/chromium", false},
-		{"/usr/bin/google-chrome", false},
-		{`C:\Program Files\Microsoft\Edge\Application\msedge.exe`, false},
-		{"brave-browser", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			result := isFirefox(tt.path)
-			if result != tt.expected {
-				t.Errorf("isFirefox(%q) = %v, want %v", tt.path, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestFindFreePort(t *testing.T) {
-	port, err := findFreePort()
-	if err != nil {
-		t.Fatalf("findFreePort() error = %v", err)
-	}
-	if port <= 0 || port > 65535 {
-		t.Errorf("findFreePort() = %d, want a valid port number", port)
-	}
-}
-
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInner(s, substr)))

--- a/skool-downloader_test.go
+++ b/skool-downloader_test.go
@@ -505,6 +505,41 @@ func TestGetBrowserCandidates_NotEmpty(t *testing.T) {
 	}
 }
 
+func TestIsFirefox(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/usr/bin/firefox", true},
+		{"/usr/bin/firefox-esr", true},
+		{`C:\Program Files\Mozilla Firefox\firefox.exe`, true},
+		{"/Applications/Firefox.app/Contents/MacOS/firefox", true},
+		{"/usr/bin/chromium", false},
+		{"/usr/bin/google-chrome", false},
+		{`C:\Program Files\Microsoft\Edge\Application\msedge.exe`, false},
+		{"brave-browser", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := isFirefox(tt.path)
+			if result != tt.expected {
+				t.Errorf("isFirefox(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindFreePort(t *testing.T) {
+	port, err := findFreePort()
+	if err != nil {
+		t.Fatalf("findFreePort() error = %v", err)
+	}
+	if port <= 0 || port > 65535 {
+		t.Errorf("findFreePort() = %d, want a valid port number", port)
+	}
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInner(s, substr)))

--- a/skool-downloader_test.go
+++ b/skool-downloader_test.go
@@ -467,6 +467,44 @@ func TestValidateConfig_NoAuth(t *testing.T) {
 	t.Skip("Skipping test that calls os.Exit")
 }
 
+func TestFindBrowser_CustomAbsolutePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeBrowser := filepath.Join(tmpDir, "fake-browser")
+	if err := os.WriteFile(fakeBrowser, []byte{}, 0755); err != nil {
+		t.Fatalf("Failed to create fake browser file: %v", err)
+	}
+
+	path, err := findBrowser(fakeBrowser)
+	if err != nil {
+		t.Fatalf("findBrowser() error = %v", err)
+	}
+	if path != fakeBrowser {
+		t.Errorf("findBrowser() = %v, want %v", path, fakeBrowser)
+	}
+}
+
+func TestFindBrowser_InvalidCustomPath(t *testing.T) {
+	_, err := findBrowser("/nonexistent/path/to/browser")
+	if err == nil {
+		t.Error("Expected error for nonexistent browser path, got nil")
+	}
+}
+
+func TestFindBrowser_InvalidBareCommand(t *testing.T) {
+	// A command name that is very unlikely to exist in PATH
+	_, err := findBrowser("skool-nonexistent-browser-xyz")
+	if err == nil {
+		t.Error("Expected error for unknown browser command, got nil")
+	}
+}
+
+func TestGetBrowserCandidates_NotEmpty(t *testing.T) {
+	candidates := getBrowserCandidates()
+	if len(candidates) == 0 {
+		t.Error("getBrowserCandidates() returned an empty list")
+	}
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInner(s, substr)))


### PR DESCRIPTION
## Summary
This PR adds intelligent browser auto-detection and allows users to specify a custom browser path via command-line flag. The application now automatically locates a supported Chromium-based browser on the system, with OS-specific search logic and fallback options.

## Key Changes
- **New `-browser` flag**: Users can optionally specify a custom browser executable path (absolute path or command name)
- **Browser auto-detection**: Implements `findBrowser()` function that searches for available Chromium-based browsers with OS-specific logic
- **OS-specific browser candidates**: Added `getBrowserCandidates()` function that returns platform-appropriate browser search paths:


currently also working on firefox support
